### PR TITLE
Fixed a problem in the motd::knife-status recipe

### DIFF
--- a/recipes/knife-status.rb
+++ b/recipes/knife-status.rb
@@ -26,7 +26,7 @@ interval ||= node['chef_client']['interval'] if node.attribute?('chef_client')
 interval ||= 1800
 
 # We need to current interval in minutes
-interval = interval / 60
+interval = Integer(interval) / 60
 
 motd '98-knife-status' do
   source    'knife-status.erb'


### PR DESCRIPTION
When it gets the "interval" value from `node['chef_client']['interval']`, it was failing to convert the seconds to minutes since the value returned was actually a string. This fix just ensures that the value in "interval" is actually an integer, so that we can do math operations on it.

See: https://github.com/opscode-cookbooks/chef-client/blob/master/attributes/default.rb#L36
