### PR TITLE
add respond_to to allow chef version compatability

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -11,5 +11,5 @@ depends          'chef_handler'
   supports os
 end
 
-source_url 'https://github.com/chr4-cookbooks/motd'
-issues_url 'https://github.com/chr4-cookbooks/motd/issues'
+source_url 'https://github.com/chr4-cookbooks/motd' if respond_to?(:source_url)
+issues_url 'https://github.com/chr4-cookbooks/motd/issues' if respond_to?(:issues_url)


### PR DESCRIPTION
Hi. This change to `metadata.rb` will allow the cookbook to run on nodes running a version of Chef that does not support `source_url` and `issues_url` in the metadata.