### PR TITLE
Remove unnecessary resource_name from resource

### DIFF
--- a/resources/motd.rb
+++ b/resources/motd.rb
@@ -19,6 +19,7 @@
 #
 
 resource_name :motd
+provides :motd
 
 default_action :create
 


### PR DESCRIPTION
This was a complaint from `cookstyle`.